### PR TITLE
remove deprecated annotations, add LoadBalancerIP

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Bitwarden Helm chart for Kubernetes
 name: bitwarden-k8s
-version: 0.1.0
+version: 0.1.1

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "bitwarden-k8s.fullname" . }}

--- a/templates/persistent-volume-claim.yaml
+++ b/templates/persistent-volume-claim.yaml
@@ -8,15 +8,14 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
-  annotations:
-  {{- if .Values.persistence.storageClass }}
-    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
-  {{- else }}
-    volume.alpha.kubernetes.io/storage-class: default
-  {{- end }}
 spec:
   accessModes:
     - {{ .Values.persistence.accessMode | quote }}
+{{- if .Values.persistence.storageClass }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- else }}
+  storageClassName: ""
+{{- end }}
   resources:
     requests:
       storage: {{ .Values.persistence.size | quote }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -9,6 +9,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: {{ .Values.service.type }}
+{{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+{{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: http

--- a/values.yaml
+++ b/values.yaml
@@ -37,6 +37,7 @@ fullnameOverride: ""
 service:
   type: ClusterIP
   port: 80
+  loadBalancerIP:
 
 ingress:
   enabled: true
@@ -72,9 +73,6 @@ affinity: {}
 ## Persist data to a persitent volume
 persistence:
   enabled: false
-  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
-  ## Default: volume.alpha.kubernetes.io/storage-class: default
-  ##
   #storageClass:
   #accessMode: ReadWriteOnce
   #size: 800Mi


### PR DESCRIPTION
Hello, thanks for creating this chart, thats exactly what I needed for kubernetes deployment. I did some changes though, storageClass annotation is deprecated and will be soon removed, + I added loadBalancerIP for specifying exact IP (useful when using k8s on bare metal, which is my case).

Btw I'd go for default value for accessMode and size, because its better to have default to just "helm install bitwarden" than annoying user with requiring setting more values than needed.

Also what about changing chart name just to "bitwarden", or "bitwarden-rs", if you want to get ppl know its rs version?  suffix "-k8s" is redundant