### PR TITLE
add deployment annotations and bump chart version

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Bitwarden Helm chart for Kubernetes
 name: bitwarden-k8s
-version: 0.1.1
+version: 0.1.2

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -2,6 +2,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "bitwarden-k8s.fullname" . }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{- range $key, $value := .Values.deploymentAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+  {{- end }}
   labels:
     app.kubernetes.io/name: {{ include "bitwarden-k8s.name" . }}
     helm.sh/chart: {{ include "bitwarden-k8s.chart" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -72,6 +72,8 @@ affinity: {}
 
 podAnnotations: {}
 
+deploymentAnnotations: {}
+
 ## Persist data to a persitent volume
 persistence:
   enabled: false


### PR DESCRIPTION
Enables support for deployment annotations. Systems like Stash will key off of deployment annotations when configuring injections.

Signed-off-by: Ryan Holt <ryan@ryanholt.net>