### PR TITLE
Add metadata in Chart.yaml

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,3 +3,10 @@ appVersion: "1.0"
 description: A Bitwarden Helm chart for Kubernetes
 name: bitwarden-k8s
 version: 0.1.5
+home: https://github.com/dani-garcia/bitwarden_rs
+icon: https://raw.githubusercontent.com/bitwarden/brand/master/icons/icon.svg
+sources:
+  - https://github.com/dani-garcia/bitwarden_rs
+maintainers:
+  - name: CodeWave
+    email: hello@codewave.eu

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -7,6 +7,8 @@ home: https://github.com/dani-garcia/bitwarden_rs
 icon: https://raw.githubusercontent.com/bitwarden/brand/master/icons/icon.svg
 sources:
   - https://github.com/dani-garcia/bitwarden_rs
+  - https://github.com/cdwv/bitwarden-k8s
 maintainers:
   - name: CodeWave
     email: hello@codewave.eu
+    url: https://codewave.eu


### PR DESCRIPTION
I'm trying to incorporate this Helm chart into a custom Helm charts repo, so I can use this as a Rancher catalog. The  helm/chart-releaser-action Github Action however is complaining about missing metadata:

```
Error: validation: chart.metadata is required
Run helm/chart-releaser-action@v1.0.0-rc.2
Installing chart-releaser...
Packaging chart 'charts/bitwarden_rs'...
Error: validation: chart.metadata is required
```