### PR TITLE
Remove default storeClassName if not specified

### DIFF
--- a/templates/persistent-volume-claim.yaml
+++ b/templates/persistent-volume-claim.yaml
@@ -14,8 +14,6 @@ spec:
     - {{ .Values.persistence.accessMode | quote }}
 {{- if .Values.persistence.storageClass }}
   storageClassName: "{{ .Values.persistence.storageClass }}"
-{{- else }}
-  storageClassName: ""
 {{- end }}
   resources:
     requests:


### PR DESCRIPTION
Instead of making the default `storageClassName: ""`, it should be removed because specifying it will override the default plugin provisioners

If the user wants to use `storageClassName: ""`, they can do so in the values.yaml