### PR TITLE
Increase default persistence size to 1Gi

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -79,6 +79,6 @@ deploymentAnnotations: {}
 persistence:
   enabled: false
   accessMode: ReadWriteOnce
-  size: 800Mi
+  size: 1Gi
   #storageClass:
   #existingClaim: "bitwarden-pvc"


### PR DESCRIPTION
Some cloud storage providers require 1Gi as a minimum