### PR TITLE
Add ability to set the deployment strategy

### DIFF
--- a/chart/bitwarden-k8s/templates/deployment.yaml
+++ b/chart/bitwarden-k8s/templates/deployment.yaml
@@ -15,6 +15,8 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  strategy:
+    type: {{ .Values.deployStrategy }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "bitwarden-k8s.name" . }}

--- a/chart/bitwarden-k8s/values.yaml
+++ b/chart/bitwarden-k8s/values.yaml
@@ -3,6 +3,7 @@
 # Declare variables to be passed into your templates.
 
 replicaCount: 1
+deployStrategy: RollingUpdate
 
 image:
   repository: bitwardenrs/server


### PR DESCRIPTION
The default strategy is `RollingUpdate` which does not work well with volume claims: they cannot be attached to the new contained, blocking it from starting up. This PR allows the user to override this strategy if needed.